### PR TITLE
Defining CODEOWNERS for the contribution training material

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+#
+# Contributors to the contribution guide
+#
+Contribution-*  @gkunz @tomas-ostling-lt @Ramses-FOSS @persan @MaArad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 #
 # Contributors to the contribution guide
 #
-Contribution-*  @gkunz @tomas-ostling-lt @Ramses-FOSS @persan @MaArad
+Contribution*  @gkunz @tomas-ostling-lt @Ramses-FOSS @persan @MaArad


### PR DESCRIPTION
CODEOWNERS will be added automatically as reviewers to new PRs. This is particularly important in our case as i) changes to the repo are infrequent, and ii) the contribution exercise asks for creating new PRs and we should close those in time.